### PR TITLE
[Trello-WUgK0ts0] adapted changes for HATEOAS for Projects svc

### DIFF
--- a/src/main/java/com/angorasix/gateway/infrastructure/filters/ValidateIsAdminGatewayFilterFactory.java
+++ b/src/main/java/com/angorasix/gateway/infrastructure/filters/ValidateIsAdminGatewayFilterFactory.java
@@ -36,10 +36,10 @@ import reactor.core.publisher.Mono;
 public class ValidateIsAdminGatewayFilterFactory extends
     AbstractGatewayFilterFactory<ValidateIsAdminGatewayFilterFactory.Config> {
 
-  private static final String PROJECT_PRESENTATION_ID_PARAM = "projectId";
+  private static final String PROJECT_ID_PARAM = "projectId";
 
   private static final String PROJECT_PRESENTATION_ID_PARAM_PLACEHOLDER =
-      ":" + PROJECT_PRESENTATION_ID_PARAM;
+      ":" + PROJECT_ID_PARAM;
 
   private static final String IS_ADMIN_RESPONSE_FIELD = "isAdmin";
 
@@ -116,10 +116,9 @@ public class ValidateIsAdminGatewayFilterFactory extends
 
   private String obtainProjectId(ServerWebExchange exchange, Object input,
       String projectIdBodyField) {
-
     return Optional.ofNullable(
             exchange.getAttribute(ServerWebExchangeUtils.URI_TEMPLATE_VARIABLES_ATTRIBUTE))
-        .map(Map.class::cast).map(attributes -> attributes.get(PROJECT_PRESENTATION_ID_PARAM))
+        .map(Map.class::cast).map(attributes -> attributes.get(PROJECT_ID_PARAM))
         .map(String.class::cast)
         .orElseGet(() -> obtainProjectIdFromInputBody(input, projectIdBodyField));
   }
@@ -138,7 +137,7 @@ public class ValidateIsAdminGatewayFilterFactory extends
 
   @Override
   public List<String> shortcutFieldOrder() {
-    return Arrays.asList("anonymousRequestAllowed", "nonAdminRequestAllowed", "projectIdBodyField");
+    return Arrays.asList("nonAdminRequestAllowed", "anonymousRequestAllowed", "projectIdBodyField");
   }
 
   /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,7 @@ configs:
       coreOutBasePath: ${A6_GATEWAY_PROJECTS_CORE_OUTBASEPATH:projects-core}
       presentationBaseURL: ${A6_GATEWAY_PROJECTS_PRESENTATION_URI:http://localhost:9083}
       presentationInBasePath: ${A6_GATEWAY_PROJECTS_PRESENTATION_INBASEPATH:projects/presentations}
+      presentationInProjectBasedPath: ${A6_GATEWAY_PROJECTS_PRESENTATION_INPROJECTBASEDPATH:projects/(?<projectId>.*?)/presentations}
       presentationOutBasePath: ${A6_GATEWAY_PROJECTS_PRESENTATION_OUTBASEPATH:projects-presentation}
     media:
       baseURL: ${A6_GATEWAY_MEDIA_URI:http://localhost:9084}

--- a/src/main/resources/routes.yml
+++ b/src/main/resources/routes.yml
@@ -46,6 +46,16 @@ spring:
           filters:
             - RewritePath=/${configs.api.projects.coreInBasePath}(?<segment>.*), /${configs.api.projects.coreOutBasePath}$\{segment}
             - ValidateIsAdmin=false,false,id
+            - SetRequestHeader=Content-Type, application/prs.hal-forms+json
+            - AddContributorHeader
+        - id: projectscore_route--post
+          uri: ${configs.api.projects.coreBaseURL}
+          predicates:
+            - Path=/projects/core
+            - Method=POST
+          filters:
+            - SetRequestHeader=Content-Type, application/prs.hal-forms+json
+            - RewritePath=/${configs.api.projects.coreInBasePath}(?<segment>.*), /${configs.api.projects.coreOutBasePath}$\{segment}
             - AddContributorHeader
         - id: projectscore_route
           uri: ${configs.api.projects.coreBaseURL}
@@ -71,14 +81,35 @@ spring:
           filters:
             - RewritePath=/${configs.api.projects.presentationInBasePath}(?<segment>.*), /${configs.api.projects.presentationOutBasePath}$\{segment}
             - ComposeFieldApi=projectId,/projects/core,ids,shallow,id,project
+        - id: projectspresentation_route--get-single
+          uri: ${configs.api.projects.presentationBaseURL}
+          predicates:
+            - Path=/projects/{projectId}/presentations/**
+            - Method=GET
+          filters:
+            - ValidateIsAdmin=true,true
+            - AddContributorHeader
+            - RewritePath=/${configs.api.projects.presentationInProjectBasedPath}(?<segment>.*), /${configs.api.projects.presentationOutBasePath}$\{segment}
+            - ComposeFieldApi=projectId,/projects/core,ids,shallow,id,project
         - id: projectspresentation_route--update
           uri: ${configs.api.projects.presentationBaseURL}
           predicates:
-            - Path=/projects/presentations/{projectPresentationId}
+            - Path=/projects/{projectId}/presentations/{projectPresentationId}
             - Method=PUT
           filters:
-            - RewritePath=/${configs.api.projects.presentationInBasePath}(?<segment>.*), /${configs.api.projects.presentationOutBasePath}$\{segment}
+            - SetRequestHeader=Content-Type, application/prs.hal-forms+json
+            - RewritePath=/${configs.api.projects.presentationInBasePath}/*(?<segment>.*), /${configs.api.projects.presentationOutBasePath}$\{segment}
             - ValidateIsAdmin=false,false,projectId
+        - id: projectspresentation_route--post
+          uri: ${configs.api.projects.presentationBaseURL}
+          predicates:
+            - Path=/projects/{projectId}/presentations/**
+            - Method=POST
+          filters:
+              - ValidateIsAdmin
+              - AddContributorHeader
+              - SetRequestHeader=Content-Type, application/prs.hal-forms+json
+              - RewritePath=/${configs.api.projects.presentationInProjectBasedPath}(?<segment>.*), /${configs.api.projects.presentationOutBasePath}$\{segment}
         - id: projectspresentation_route
           uri: ${configs.api.projects.presentationBaseURL}
           predicates:
@@ -101,7 +132,7 @@ spring:
             - Path=/clubs/well-known/{projectId}/{type}
             - Method=PATCH
           filters:
-            - ValidateIsAdmin=false,true
+            - ValidateIsAdmin=true
             - AddContributorHeader
             - RewritePath=/${configs.api.clubs.inBasePath}(?<segment>.*), /${configs.api.clubs.outBasePath}$\{segment}
         - id: clubs_route--post-add-member


### PR DESCRIPTION
Using HAL header for POST and PUTs
Using projectId in projectPresentations routes, to check if contributor is adming before sending request (would be required to check associated projectId)